### PR TITLE
Seq924 move gatekeeper to pmb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,13 +15,10 @@ gem 'bootstrap-sass'
 gem 'bootstrap-datepicker-rails'
 gem 'hashie'
 gem 'exception_notification'
+gem 'sanger_barcode_format', github: 'sanger/sanger_barcode_format', branch: 'development'
 
-gem 'sequencescape-client-api',
-    github: 'sanger/sequencescape-client-api',
-    branch: 'rails_4',
-    require: 'sequencescape'
-gem 'sanger_barcode',
-    github: 'sanger/sanger_barcode'
+gem 'sequencescape-client-api', require: 'sequencescape'
+gem 'pmb-client', '0.1.0', github: 'sanger/pmb-client'
 
 group :development do
   gem 'pry'
@@ -36,6 +33,7 @@ end
 group :test do
   gem 'minitest'
   gem 'mocha'
+  gem 'timecop'
   gem 'poltergeist'
   gem 'launchy'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,22 @@
 GIT
+  remote: git://github.com/sanger/pmb-client.git
+  revision: 016f151a3bde84448ed64e528259c3511282dcdb
+  specs:
+    pmb-client (0.1.0)
+      json_api_client (~> 1.1)
+
+GIT
   remote: git://github.com/sanger/psd_logger.git
   revision: dd2d634114df75b1d8535715c169a7fc99521389
   specs:
     psd_logger (0.1.6)
 
 GIT
-  remote: git://github.com/sanger/sanger_barcode.git
-  revision: 11fb6cc077475d4a0ba6f8225fd5bdab60d5dc88
+  remote: git://github.com/sanger/sanger_barcode_format.git
+  revision: 35846331c2b88d049a14b7cace08e18664494de1
+  branch: development
   specs:
-    sanger_barcode (0.2.1)
-      savon (= 0.9.2)
-
-GIT
-  remote: git://github.com/sanger/sequencescape-client-api.git
-  revision: dc33ac896f6edd4caab0a9c19525c307e6178513
-  branch: rails_4
-  specs:
-    sequencescape-client-api (0.2.2)
-      activemodel (~> 4)
-      activesupport (~> 4)
-      i18n
-      yajl-ruby (~> 1.1.0)
+    sanger_barcode_format (0.1.1)
 
 GEM
   remote: http://rubygems.org/
@@ -77,17 +73,23 @@ GEM
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
     execjs (2.5.2)
-    gyoku (1.3.1)
-      builder (>= 2.1.2)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     hashie (3.4.1)
-    httpi (2.4.0)
-      rack
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    json_api_client (1.9.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.2)
+      faraday (~> 0.15, >= 0.15.2)
+      faraday_middleware (~> 0.9)
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.19)
@@ -115,9 +117,9 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    nori (2.6.0)
     parallel (1.12.1)
     parser (2.5.0.5)
       ast (~> 2.4.0)
@@ -167,12 +169,11 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
-    savon (0.9.2)
-      builder (>= 2.1.2)
-      gyoku (>= 0.4.0)
-      httpi (>= 0.7.8)
-      nokogiri (>= 1.4.0)
-      nori (>= 0.2.0)
+    sequencescape-client-api (0.3.6)
+      activemodel (>= 4.0.0, < 5.2)
+      activesupport (>= 4.0.0, < 5.2)
+      i18n
+      yajl-ruby (>= 1.3.1)
     slop (3.6.0)
     sprockets (3.1.0)
       rack (~> 1.0)
@@ -186,6 +187,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.6)
     tilt (1.4.1)
+    timecop (0.9.1)
     tzinfo (0.3.54)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
@@ -196,7 +198,7 @@ GEM
     websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.1.0)
+    yajl-ruby (1.4.1)
     yard (0.9.12)
 
 PLATFORMS
@@ -213,16 +215,18 @@ DEPENDENCIES
   minitest
   minitest-rails-capybara
   mocha
+  pmb-client (= 0.1.0)!
   poltergeist
   pry
   psd_logger!
   puma
   rails (~> 4.0.2)
   rubocop
-  sanger_barcode!
+  sanger_barcode_format!
   sass-rails (>= 3.2)
-  sequencescape-client-api!
+  sequencescape-client-api
   therubyracer
+  timecop
   uglifier (>= 1.3.0)
   yard
 

--- a/app/controllers/barcode_labels_controller.rb
+++ b/app/controllers/barcode_labels_controller.rb
@@ -27,7 +27,7 @@ class BarcodeLabelsController < ApplicationController
 
   def generate_labels
     @labels = (params[:numbers] || []).map do |_, number|
-      Sanger::Barcode::Printing::Label.new(
+      BarcodeSheet::Label.new(
         prefix: params[:prefix],
         number: number,
         study: params[:study]

--- a/app/controllers/qcables_controller.rb
+++ b/app/controllers/qcables_controller.rb
@@ -11,9 +11,6 @@ class QcablesController < ApplicationController
   # This action should generally get called through the nested
   # lot/qcables route, which will provide our lot id.
   def create
-    # If we have the lot type cached in settings, use that.
-    qcable_name = (Settings.lot_types[@lot.lot_type_name] || @lot.lot_type).qcable_name
-
     qc_creator = api.qcable_creator.create!(
       user: @user.uuid,
       lot: @lot.uuid,
@@ -41,6 +38,11 @@ class QcablesController < ApplicationController
   end
 
   private
+
+  def qcable_name
+    # If we have the lot type cached in settings, use that.
+    (Settings.lot_types[@lot.lot_type_name] || @lot.lot_type).qcable_name
+  end
 
   def find_lot
     @lot = api.lot.find(params[:lot_id])

--- a/app/models/barcode_sheet/label.rb
+++ b/app/models/barcode_sheet/label.rb
@@ -34,7 +34,7 @@ class BarcodeSheet::Label
         bottom_left: human_readable,
         top_right: human_readable,
         bottom_right: lot_template,
-        barcode: machine_barcode
+        barcode: code39_barcode
       }
     }
   end
@@ -47,18 +47,22 @@ class BarcodeSheet::Label
         bottom_line: date,
         round_label_top_line: @prefix,
         round_label_bottom_line: @number,
-        barcode: machine_barcode.to_s
+        barcode: ean13_barcode.to_s
       }
     }
   end
 
   private
 
+  def code39_barcode
+    @barcode || SBCF::SangerBarcode.new(prefix: @prefix, number: @number).human_barcode
+  end
+
   def lot_template
     @legacy_study || "#{@lot}:#{@template}"
   end
 
-  def machine_barcode
+  def ean13_barcode
     @barcode || SBCF::SangerBarcode.new(prefix: @prefix, number: @number).machine_barcode
   end
 

--- a/app/models/barcode_sheet/label.rb
+++ b/app/models/barcode_sheet/label.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Translates the label information into the correct format for the template
+class BarcodeSheet::Label
+  #
+  # Create a label with the information expected to appear.
+  # JG note: As of Feb 2019 we are only sending the prefix/number across the old
+  # api, not the human readable for itself. This adds forward compatibility for passing
+  # through a human readable form, which will be important if we change our barcode
+  # format.
+  # @param barcode: [String] The actual value of the barcode
+  # @param prefix: [String] the prefix of the human readable barcode
+  # @param number: [String] the number of the human readable barcode
+  # @param human_readable: [String] the human readable barcode (if prefix and number aren't suitable)
+  # @param lot: [String] The lot number
+  # @param template: [String] The template name
+  # @param study: [String] Legacy compatibility field
+  #
+  # @return [type] [description]
+  def initialize(prefix:, number:, lot: nil, template: nil, barcode: nil, human_readable: nil, study: nil)
+    @barcode = barcode
+    @prefix = prefix
+    @number = number
+    @human_readable = human_readable
+    @lot = lot
+    @template = template
+    @legacy_study = study
+  end
+
+  def plate
+    {
+      main_label: {
+        top_left: date,
+        bottom_left: human_readable,
+        top_right: human_readable,
+        bottom_right: lot_template,
+        barcode: machine_barcode
+      }
+    }
+  end
+
+  def tube
+    {
+      main_label: {
+        top_line: lot_template,
+        middle_line: asset.barcode_number,
+        bottom_line: date,
+        round_label_top_line: @prefix,
+        round_label_bottom_line: @number,
+        barcode: machine_barcode.to_s
+      }
+    }
+  end
+
+  private
+
+  def lot_template
+    @legacy_study || "#{@lot}:#{@template}"
+  end
+
+  def machine_barcode
+    @barcode || SBCF::SangerBarcode.new(prefix: @prefix, number: @number).machine_barcode
+  end
+
+  def human_readable
+    @human_readable || SBCF::SangerBarcode.new(prefix: @prefix, number: @number).human_barcode
+  end
+
+  def date
+    Time.zone.today.strftime('%d-%b-%Y')
+  end
+end

--- a/app/models/gatekeeper/qcable.rb
+++ b/app/models/gatekeeper/qcable.rb
@@ -12,4 +12,10 @@ class Gatekeeper::Qcable < Sequencescape::Qcable
   def in_lot?(lot)
     self.lot.uuid == lot.uuid
   end
+
+  attribute_group :barcode do
+    attribute_accessor :prefix, :number     # The pieces that make up a barcode
+    attribute_accessor :ean13               # The EAN13 barcode number
+    attribute_accessor :machine             # The EAN13 barcode number
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -121,6 +121,11 @@ module Gatekeeper
       },
       'library_type' => 'QA1'
     }
+
+    config.printer_type_options = {
+      '1D Tube' => { label: :tube, template: 'sqsc_1dtube_label_template' },
+      '96 Well Plate' => { label: :plate, template: 'sqsc_96plate_label_template_code39' }
+    }
   end
 
   begin

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,8 +32,8 @@ Gatekeeper::Application.configure do
   # Set up the API connection options
   config.api_connection_options               = ActiveSupport::OrderedOptions.new
   config.api_connection_options.namespace     = 'Gatekeeper'
-  config.api_connection_options.url           = 'http://localhost:3000/api/1/'
-  config.api_connection_options.authorisation = 'development'
+  config.api_connection_options.url           = ENV.fetch('API_URL', 'http://localhost:3000/api/1/')
+  config.api_connection_options.authorisation = ENV.fetch('API_KEY', 'development')
 
   config.support_mail = 'example@example.com'
 
@@ -46,4 +46,6 @@ Gatekeeper::Application.configure do
   config.suggested_templates = ActiveSupport::OrderedOptions.new
   config.suggested_templates.plate_template      = :all
   config.suggested_templates.tag_layout_template = :all
+
+  config.pmb_uri = ENV.fetch('PMB_URI', 'http://localhost:3002/v1/')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,6 @@ Gatekeeper::Application.configure do
   config.suggested_templates = ActiveSupport::OrderedOptions.new
   config.suggested_templates.plate_template      = :all
   config.suggested_templates.tag_layout_template = :all
+
+  config.pmb_uri = 'http://example.com:3002/v1/'
 end

--- a/config/initializers/pmb_server_setup.rb
+++ b/config/initializers/pmb_server_setup.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'pmb-client'
+
+PMB::Base.site = Rails.configuration.pmb_uri

--- a/lib/barcode.rb
+++ b/lib/barcode.rb
@@ -2,6 +2,6 @@
 
 module Barcode
   def self.calculate_barcode(prefix, number)
-    SBCF::SangerBarcode.from_prefix_and_number(prefix,number).machine_barcode
+    SBCF::SangerBarcode.from_prefix_and_number(prefix, number).machine_barcode
   end
 end

--- a/lib/barcode.rb
+++ b/lib/barcode.rb
@@ -1,61 +1,7 @@
 # frozen_string_literal: true
 
 module Barcode
-  InvalidBarcode = Class.new(StandardError)
-
   def self.calculate_barcode(prefix, number)
-    barcode = calculate_sanger_barcode(prefix, number)
-    barcode * 10 + calculate_ean13(barcode)
-  end
-
-  def self.number_to_human(code)
-    if /^(...)(.*)(...)$/ =~ code.to_s
-      return $2.to_i
-    end
-    raise InvalidBarcode
-  end
-
-  # NT23432S => 398002343283
-  private_class_method
-
-  def self.calculate_sanger_barcode(prefix, number)
-    raise ArgumentError, "Number : #{number} to big to generate a barcode." if number.to_s.size > 7
-    checksum = calculate_checksum(prefix, number)
-    barcode = prefix_to_number(prefix) + (number * 100) + checksum
-  end
-
-  def self.calculate_checksum(prefix, number)
-    string = prefix + number.to_s
-    len = string.length
-
-    sum = (0...len).inject(0) do |s, i|
-      s + (string.getbyte(i) * (len - i))
-    end
-    (sum % 23 + 'A'.getbyte(0))
-  end
-
-  def self.calculate_ean13(code)
-    calculate_ean(code)
-  end
-
-  def self.calculate_ean(code, initial_weight = 3)
-    # The EAN is calculated by adding each digit modulo 10 ten weighted by 1 or 3 ( in seq)
-    code = code.to_i
-    ean = 0
-    weight = initial_weight
-    while code > 0
-      code, c = code.divmod 10
-      ean += c * weight % 10
-      weight = weight == 1 ? 3 : 1
-    end
-    (10 - ean) % 10
-  end
-
-  def self.prefix_to_number(prefix)
-    first  = prefix.getbyte(0) - 64
-    second = prefix.getbyte(1) - 64
-    first  = 0 if first < 0
-    second = 0 if second < 0
-    return ((first * 27) + second) * 1000000000
+    SBCF::SangerBarcode.from_prefix_and_number(prefix,number).machine_barcode
   end
 end

--- a/test/controllers/qcables_controller_test.rb
+++ b/test/controllers/qcables_controller_test.rb
@@ -24,7 +24,10 @@ class QcablesControllerTest < ActionController::TestCase
 
     target_printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
 
-    (1..10).map { |i| Sanger::Barcode::Printing::Label.expects(:new).with(prefix: 'DN', number: i.to_s, study: '123456789:Example Tag Layout') }
+    (1..10).map do |i|
+      human_readable = SBCF::SangerBarcode.new(prefix: 'DN', number: i).human_barcode
+      BarcodeSheet::Label.expects(:new).with(prefix: 'DN', number: i.to_s, barcode: human_readable, lot: '123456789', template: 'Example Tag Layout')
+    end
 
     mock_printer = mock('printer')
     mock_printer.expects(:print!).returns(true)

--- a/test/fixtures/api_models.yml
+++ b/test/fixtures/api_models.yml
@@ -31,7 +31,7 @@
 :lot:
   '11111111-2222-3333-4444-555555555556':
     :attributes:
-      :lot_number: 123456789
+      :lot_number: '123456789'
       :received_at: 2013-02-01
       :lot_type_name: IDT Tags
       :template_name: Example Tag Layout
@@ -52,7 +52,7 @@
       - '11111111-2222-3333-4444-100000000010'
   '11111111-2222-3333-4444-555555555557':
     :attributes:
-      :lot_number: 123456790
+      :lot_number: '123456790'
       :received_at: 2013-02-01
       :lot_type_name: IDT Reporters
       :template_name: Example Plate Layout
@@ -64,7 +64,7 @@
       - '11111111-2222-3333-4444-200000000010'
   '11111111-2222-3333-4444-555555555567':
     :attributes:
-      :lot_number: 123456790
+      :lot_number: '123456790'
       :received_at: 2013-02-01
       :lot_type_name: Tag 2
       :template_name: Second Tag
@@ -97,6 +97,7 @@
       :barcode:
         :prefix: DN
         :number: '1'
+        :machine: 'DN1S'
         :ean13: '122000000183'
       :state: created
       :stamp_bed:
@@ -110,6 +111,7 @@
       :barcode:
         :prefix: DN
         :number: '2'
+        :machine: 'DN2T'
         :ean13: '122000000284'
       :state: created
       :stamp_bed: nil
@@ -123,6 +125,7 @@
       :barcode:
         :prefix: DN
         :number: '3'
+        :machine: 'DN3U'
         :ean13: '122000000385'
       :state: qc_in_progress
       :stamp_bed: '1'
@@ -136,6 +139,7 @@
       :barcode:
         :prefix: DN
         :number: '4'
+        :machine: 'DN4V'
         :ean13: '122000000486'
       :state: destroyed
       :stamp_bed: '2'
@@ -149,6 +153,7 @@
       :barcode:
         :prefix: DN
         :number: '5'
+        :machine: 'DN5W'
         :ean13: '122000000587'
       :state: failed
       :stamp_bed: '4'
@@ -162,6 +167,7 @@
       :barcode:
         :prefix: DN
         :number: '6'
+        :machine: 'DN6A'
         :ean13: '122000000665'
       :state: exhausted
       :stamp_bed: '3'
@@ -175,6 +181,7 @@
       :barcode:
         :prefix: DN
         :number: '7'
+        :machine: 'DN7B'
         :ean13: '122000000766'
       :state: passed
       :stamp_bed: '5'
@@ -188,6 +195,7 @@
       :barcode:
         :prefix: DN
         :number: '8'
+        :machine: 'DN8C'
         :ean13: '122000000867'
       :state: pending
       :stamp_bed: '6'
@@ -201,6 +209,7 @@
       :barcode:
         :prefix: DN
         :number: '9'
+        :machine: 'DN9D'
         :ean13: '122000000968'
       :state: pending
       :stamp_bed: '7'
@@ -214,6 +223,7 @@
       :barcode:
         :prefix: DN
         :number: '10'
+        :machine: 'DN10I'
         :ean13: '122000001069'
       :state: available
       :stamp_bed: '8'

--- a/test/models/barcode_calculate_test.rb
+++ b/test/models/barcode_calculate_test.rb
@@ -13,14 +13,4 @@ class BarcodeCalculateTest < ActiveSupport::TestCase
     assert_equal 580000001806, Barcode.calculate_barcode('BD', 1)
     assert_equal 1220000001831, Barcode.calculate_barcode('DN', 1)
   end
-
-  test 'validate split' do
-    # Barcode generation is weird.
-    # The main issue being that any prefixes of less than CS
-    # seem to have a leading zero in the prefix, so we end up with
-    # what appears to be a 12 digit ean13. This is what the scanners
-    # read back, so is probably 'correct,' just unexpected.
-    assert_equal 1, Barcode.number_to_human('580000001806')
-    assert_equal 1, Barcode.number_to_human('1220000001831')
-  end
 end

--- a/test/models/barcode_sheet_test.rb
+++ b/test/models/barcode_sheet_test.rb
@@ -2,23 +2,56 @@
 
 require 'test_helper'
 require 'mock_api'
+require_relative '../support/pmb_support'
 
 class BarcodeSheetTest < ActiveSupport::TestCase
   include MockApi
 
   setup do
+    PMB::TestSuiteStubs = Faraday::Adapter::Test::Stubs.new
+    PMB::Base.connection.delete(Faraday::Adapter::NetHttp)
+    PMB::Base.connection.faraday.adapter :test, PMB::TestSuiteStubs
     mock_api
+    @printer_name = 'printer'
+    @label_template_name = 'sqsc_96plate_label_template_code39'
+    @label_template_id = '1'
+    @label_template_query = { 'filter[name]': @label_template_name, 'page[page]': 1, 'page[per_page]': 1 }
+    @label_template_url = "/v1/label_templates?#{URI.encode_www_form(@label_template_query)}"
   end
 
   test '#print!' do
-    labels = [Sanger::Barcode::Printing::Label.new(prefix: 'DN', number: 1, study: 'test')]
+    Timecop.freeze(Date.parse('02-02-2019')) do
+      recieved_labels = [BarcodeSheet::Label.new(barcode: 'DN1S', prefix: 'DN', number: '1', lot: 'lot_number', template: 'tag_set')]
 
-    mock_service = mock('service')
-    mock_service.expects(:print_labels).with(labels, 'plate_example', 1)
-    Sanger::Barcode::Printing::Service.expects(:new).with('http://localhost/mock_service.wsdl').returns(mock_service)
+      sent_labels = [{
+        top_left: '02-Feb-2019',
+        bottom_left: 'DN1S',
+        top_right: 'DN1S',
+        bottom_right: 'lot_number:tag_set',
+        barcode: 'DN1S'
+      }]
 
-    printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
+      printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
 
-    BarcodeSheet.new(printer, labels).print!
+      PMB::TestSuiteStubs.get(@label_template_url) do |_env|
+        [
+          200,
+          { content_type: 'application/json' },
+          PmbSupport.label_template_response(@label_template_id, @label_template_name)
+        ]
+      end
+
+      PMB::TestSuiteStubs.post('/v1/print_jobs', PmbSupport.print_job_post('plate_example', @label_template_id, sent_labels)) do |_env|
+        [
+          200,
+          { content_type: 'application/json' },
+          PmbSupport.print_job_response('plate_example', @label_template_id, sent_labels)
+        ]
+      end
+
+      BarcodeSheet.new(printer, recieved_labels).print!
+
+      PMB::TestSuiteStubs.verify_stubbed_calls
+    end
   end
 end

--- a/test/support/pmb_support.rb
+++ b/test/support/pmb_support.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Helper methods to assist with testing PMB
+module PmbSupport
+  def self.print_job_response(printer_name, template_id, labels = [])
+    {
+      data: {
+        id: '',
+        type: 'print_jobs',
+        attributes: {
+          printer_name: printer_name,
+          label_template_id: template_id.to_s,
+          labels: labels_to_label_hash(labels)
+        }
+      }
+    }.to_json
+  end
+
+  def self.print_job_post(printer_name, template_id, labels = [])
+    {
+      data: {
+        type: 'print_jobs',
+        attributes: {
+          printer_name: printer_name,
+          label_template_id: template_id,
+          labels: labels_to_label_hash(labels)
+        }
+      }
+    }.to_json
+  end
+
+  def self.labels_to_label_hash(labels)
+    {
+      body: labels.map { |attributes| { main_label: attributes } }
+    }
+  end
+
+  def self.label_template_response(id, name)
+    {
+      data:
+        [
+          {
+            id: id.to_s,
+            type: 'label_templates',
+            attributes: { name: name }
+          }
+        ]
+    }.to_json
+  end
+end


### PR DESCRIPTION
- Switch to PMB
- Switch to code39 for plates

Limitation:
- If someone re-prints an older tag plate barcode, they'll get a DN code39 version, not an ean13. Avoiding this would require re-working the barcode labels controller, as well as a view and a javascript component. I decided to keep thing simple.