### PR TITLE
Added a hack to ensure sprint labels actually print something.

### DIFF
--- a/app/controllers/qcables_controller.rb
+++ b/app/controllers/qcables_controller.rb
@@ -63,5 +63,4 @@ class QcablesController < ApplicationController
   def find_lot
     @lot = api.lot.find(params[:lot_id])
   end
-
 end

--- a/app/controllers/qcables_controller.rb
+++ b/app/controllers/qcables_controller.rb
@@ -64,11 +64,4 @@ class QcablesController < ApplicationController
     @lot = api.lot.find(params[:lot_id])
   end
 
-  def validate_plate_count
-    range = Gatekeeper::Application.config.stamp_range
-    step  = Gatekeeper::Application.config.stamp_step
-    return true if range.cover?(params[:plate_number].to_i) && (params[:plate_number].to_i % step == 0)
-    flash[:danger] = "Number of plates created must be a multiple of #{step} between #{range.first} and #{range.last} inclusive"
-    redirect_back fallback_location: lots_path
-  end
 end

--- a/app/controllers/qcables_controller.rb
+++ b/app/controllers/qcables_controller.rb
@@ -6,7 +6,7 @@ class QcablesController < ApplicationController
   include BarcodePrinting
 
   before_action :find_user, :find_lot
-  before_action :validate_plate_count, :find_printer, only: [:create]
+  before_action :find_printer, only: [:create]
 
   ##
   # This action should generally get called through the nested

--- a/app/models/barcode_sheet.rb
+++ b/app/models/barcode_sheet.rb
@@ -39,7 +39,7 @@ class BarcodeSheet
     response = SPrintClient.send_print_request(
       printer_name,
       "#{label_template_name}.yml.erb",
-      all_labels
+      sprint_labels
     )
     raise(PrintError, 'There was an error sending a print request to SPrint') unless response.code == '200'
   end

--- a/app/models/barcode_sheet.rb
+++ b/app/models/barcode_sheet.rb
@@ -44,6 +44,10 @@ class BarcodeSheet
     raise(PrintError, 'There was an error sending a print request to SPrint') unless response.code == '200'
   end
 
+  def sprint_labels
+    all_labels.pluck(:main_label)
+  end
+
   private
 
   def config

--- a/test/controllers/qcables_controller_test.rb
+++ b/test/controllers/qcables_controller_test.rb
@@ -98,23 +98,6 @@ class QcablesControllerTest < ActionController::TestCase
     assert_equal 'User could not be found, is your swipecard registered?', flash[:danger]
   end
 
-  test 'create outside range or step' do
-    api.mock_user('abcdef', '11111111-2222-3333-4444-555555555555')
-
-    request.env['HTTP_REFERER'] = lot_url('11111111-2222-3333-4444-555555555556')
-
-    [0, -12, 999999, 11].each do |i|
-      post :create, params: {
-           user_swipecard: 'abcdef',
-           lot_id: '11111111-2222-3333-4444-555555555556',
-           plate_number: i,
-           barcode_printer: 'baac0dea-0000-0000-0000-000000000000'
-      }
-      assert_redirected_to controller: :lots, action: :show, id: '11111111-2222-3333-4444-555555555556'
-      assert_equal 'Number of plates created must be a multiple of 10 between 10 and 500 inclusive', flash[:danger]
-    end
-  end
-
   test 'upload' do
     api.mock_user('abcdef', '11111111-2222-3333-4444-555555555555')
 

--- a/test/models/barcode_sheet_test.rb
+++ b/test/models/barcode_sheet_test.rb
@@ -25,6 +25,7 @@ class BarcodeSheetTest < ActiveSupport::TestCase
     barcode_sheet = BarcodeSheet.new(printer, received_labels)
     assert_equal barcode_sheet.printer.name, @printer_name
     assert_equal barcode_sheet.labels, received_labels
+    assert_equal barcode_sheet.sprint_labels, [received_labels.first.plate[:main_label]]
   end
 
   test '#print! when print_service is PMB' do


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* Extract main label from labels for sprint so that stuff actuall prints
* Removed constraint that labels are printing in a multiple of 10 as this is not required in the lab and is wasting a lot of labels.
* ...
