### PR TITLE
Revert "Update yard 0.9.28 → 0.9.34 (minor)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,13 +312,15 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.4.2)
+    webrick (1.7.0)
     websocket (1.2.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.34)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS


### PR DESCRIPTION
Reverts sanger/gatekeeper#343

I am reverting it as the merge cannot be tested at the moment. I suspect a GitHub issue although GitHub status shows no issues. The following in the log might be because API call for coverage is returning an HTML response:

```
/home/runner/work/gatekeeper/gatekeeper/cc-reporter after-build --exit-code 0
Error: invalid character '<' looking for beginning of value
```