### PR TITLE
Y24-292 - [BUG] Exception 27/08/24 at 9:31

### DIFF
--- a/app/controllers/barcode_labels_controller.rb
+++ b/app/controllers/barcode_labels_controller.rb
@@ -27,7 +27,8 @@ class BarcodeLabelsController < ApplicationController
   private
 
   def generate_labels
-    @labels = (params[:numbers] || []).map do |_, number|
+    permitted_params = params.permit(:prefix, :study, :numbers)
+    @labels = (permitted_params[:numbers] || []).map do |_, number|
       BarcodeSheet::Label.new(
         prefix: params[:prefix],
         number:,


### PR DESCRIPTION
undefined method `map' for #<ActionController::Parameters {"61854"=>"61854"} permitted: false>


ActionController::Parameters: Rails wraps incoming parameters in this class to help prevent mass assignment vulnerabilities. We must permit parameters you want to use.
