### PR TITLE
Create "QCable Creators" through the Sequencescape v2 API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'drb'
 gem 'exception_notification'
 gem 'hashie'
 gem 'jquery-rails'
+gem "json_api_client"
 gem 'mutex_m'
 gem 'oj', '~> 3.13'
 gem 'pmb-client', '0.1.0', github: 'sanger/pmb-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,7 @@ DEPENDENCIES
   exception_notification
   hashie
   jquery-rails
+  json_api_client
   launchy
   listen
   minitest

--- a/app/resources/sequencescape/api/v2/base.rb
+++ b/app/resources/sequencescape/api/v2/base.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Sequencescape::Api::V2::Base < JsonApiClient::Resource
+  self.site = Gatekeeper::Application.config.api_connection_options.url_v2
+  connection_options[:headers] = { "X-Sequencescape-Client-Id" => Gatekeeper::Application.config.api_connection_options.authorisation }
+end

--- a/app/resources/sequencescape/api/v2/lot.rb
+++ b/app/resources/sequencescape/api/v2/lot.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Represents a Lot using the Sequencescape V2 API
+class Sequencescape::Api::V2::Lot < Sequencescape::Api::V2::Base
+end

--- a/app/resources/sequencescape/api/v2/qcable_creator.rb
+++ b/app/resources/sequencescape/api/v2/qcable_creator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Represents a QcableCreator using the Sequencescape V2 API
+class Sequencescape::Api::V2::QcableCreator < Sequencescape::Api::V2::Base
+  has_one :lot
+  has_one :user
+  # has_many :qcables
+end

--- a/app/resources/sequencescape/api/v2/user.rb
+++ b/app/resources/sequencescape/api/v2/user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Represents a User using the Sequencescape V2 API
+class Sequencescape::Api::V2::User < Sequencescape::Api::V2::Base
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,7 @@ Rails.application.configure do
   config.api_connection_options               = ActiveSupport::OrderedOptions.new
   config.api_connection_options.namespace     = 'Gatekeeper'
   config.api_connection_options.url           = ENV.fetch('API_URL', 'http://localhost:3000/api/1/')
+  config.api_connection_options.url_v2       = ENV.fetch('API_URL', 'http://localhost:3000/api/v2/')
   config.api_connection_options.authorisation = ENV.fetch('API_KEY', 'development')
 
   # We can either pass in an array of printer names, or accept all printers with :all


### PR DESCRIPTION
Add JSON API Client gem, to help calling Sequencescape v2 API. Add first few resources, to support creation of QCable Creators.

Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
