### PR TITLE
Y25-478 - Disable unused parts of UI - Part 2 - Lot Types

### DIFF
--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -62,8 +62,8 @@ namespace :config do
 
       configuration[:lot_types] = {}.tap do |lot_types|
         puts 'Preparing lot types ...'
-        api.lot_type.each do |lot_type|
-          lot_types[lot_type.name] = { uuid: lot_type.uuid, template_class: lot_type.template_class, printer_type: lot_type.printer_type, qcable_name: lot_type.qcable_name }
+        Sequencescape::Api::V2::LotType.all.each do |lot_type|
+          lot_types[lot_type.name] = { uuid: lot_type.uuid, template_class: lot_type.template_type, printer_type: lot_type.printer_type, qcable_name: lot_type.qcable_name }
         end
       end
 

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -62,7 +62,8 @@ namespace :config do
 
       configuration[:lot_types] = {}.tap do |lot_types|
         puts 'Preparing lot types ...'
-        Sequencescape::Api::V2::LotType.find_each do |lot_type|
+        # Rubocop is wrong here - find_each is an unknown method
+        Sequencescape::Api::V2::LotType.all.each do |lot_type| # rubocop:disable Rails/FindEach
           lot_types[lot_type.name] = { uuid: lot_type.uuid, template_class: lot_type.template_class, printer_type: lot_type.printer_type, qcable_name: lot_type.qcable_name }
         end
       end

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -62,7 +62,7 @@ namespace :config do
 
       configuration[:lot_types] = {}.tap do |lot_types|
         puts 'Preparing lot types ...'
-        Sequencescape::Api::V2::LotType.all.each do |lot_type|
+        Sequencescape::Api::V2::LotType.find_each do |lot_type|
           lot_types[lot_type.name] = { uuid: lot_type.uuid, template_class: lot_type.template_class, printer_type: lot_type.printer_type, qcable_name: lot_type.qcable_name }
         end
       end

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -63,7 +63,7 @@ namespace :config do
       configuration[:lot_types] = {}.tap do |lot_types|
         puts 'Preparing lot types ...'
         Sequencescape::Api::V2::LotType.all.each do |lot_type|
-          lot_types[lot_type.name] = { uuid: lot_type.uuid, template_class: lot_type.template_type, printer_type: lot_type.printer_type, qcable_name: lot_type.qcable_name }
+          lot_types[lot_type.name] = { uuid: lot_type.uuid, template_class: lot_type.template_class, printer_type: lot_type.printer_type, qcable_name: lot_type.qcable_name }
         end
       end
 


### PR DESCRIPTION
Closes #

See Sequencescape PR (this is dependent on it) - https://github.com/sanger/sequencescape/pull/5181/files

#### Changes proposed in this pull request

- convert lot type retrieval when building settings file to use v2 api, so that it uses the new filter on SS API side and only retrieves 'active' lot types, hence removing unnecessary options from the front page. 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
