### PR TITLE
Trigger 'check release' Github action when PR marked as ready for review

### DIFF
--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
     branches:
       - master
+    types:
+      # defaults
+      - opened
+      - synchronize
+      - reopened
+      # custom
+      - ready_for_review # required for Github-created PRs
 
 jobs:
   check-release-version:


### PR DESCRIPTION

Closes #

#### Changes proposed in this pull request

- add 'ready_for_review' so that check release action is triggered when the automated PRs into main are marked as ready

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
