### PR TITLE
Y25-482 - Barcode printing using Sequencescape V2 API

### DIFF
--- a/app/controllers/concerns/barcode_printing.rb
+++ b/app/controllers/concerns/barcode_printing.rb
@@ -4,10 +4,6 @@
 # Include to provide barcode printing functionality to a controller
 module BarcodePrinting
   def find_printer
-    @printer = api.barcode_printer.find(params[:barcode_printer])
-  end
-
-  def find_printer_v2
-    @printer_v2 = Sequencescape::Api::V2::BarcodePrinter.where(uuid: params[:barcode_printer]).first
+    @printer = Sequencescape::Api::V2::BarcodePrinter.where(uuid: params[:barcode_printer]).first
   end
 end

--- a/app/controllers/qcables_controller.rb
+++ b/app/controllers/qcables_controller.rb
@@ -6,7 +6,7 @@ class QcablesController < ApplicationController
   include BarcodePrinting
 
   before_action :find_user, :find_lot
-  before_action :find_printer_v2, only: [:create]
+  before_action :find_printer, only: [:create]
 
   ##
   # This action should generally get called through the nested
@@ -87,7 +87,7 @@ class QcablesController < ApplicationController
     end
 
     begin
-      BarcodeSheet.new(@printer_v2, labels).print!
+      BarcodeSheet.new(@printer, labels).print!
     rescue BarcodeSheet::PrintError => e
       flash[:danger] = "There was a problem printing your barcodes. Your #{qcable_name.pluralize} have still been created. #{e.message}"
     rescue Errno::ECONNREFUSED

--- a/test/controllers/barcode_labels_controller_test.rb
+++ b/test/controllers/barcode_labels_controller_test.rb
@@ -7,8 +7,6 @@ class BarcodeLabelsControllerTest < ActionController::TestCase
 
   setup do
     mock_api
-    printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
-    printer.stubs(:print_service).returns('PMB')
     @params = {
       prefix: 'ABC',
       study: 'Study1',
@@ -19,6 +17,9 @@ class BarcodeLabelsControllerTest < ActionController::TestCase
   end
 
   test 'should print barcodes and return success' do
+    Sequencescape::Api::V2::BarcodePrinter.expects(:where).returns([Sequencescape::Api::V2::BarcodePrinter.new(
+      print_service: 'PMB', name: 'Test Printer', barcode_type: 'something'
+    )])
     mock_barcode_sheet = mock('printer')
     mock_barcode_sheet.expects(:print!).returns(true)
     BarcodeSheet.expects(:new).returns(mock_barcode_sheet)
@@ -31,6 +32,9 @@ class BarcodeLabelsControllerTest < ActionController::TestCase
   end
 
   test 'should handle BarcodeSheet::PrintError' do
+    Sequencescape::Api::V2::BarcodePrinter.expects(:where).returns([Sequencescape::Api::V2::BarcodePrinter.new(
+      print_service: 'PMB', name: 'Test Printer', barcode_type: 'something'
+    )])
     mock_barcode_sheet = mock('printer')
     mock_barcode_sheet.expects(:print!).raises(BarcodeSheet::PrintError.new('Printer jammed'))
     BarcodeSheet.expects(:new).returns(mock_barcode_sheet)
@@ -44,6 +48,9 @@ class BarcodeLabelsControllerTest < ActionController::TestCase
   end
 
   test 'should handle connection refused error' do
+    Sequencescape::Api::V2::BarcodePrinter.expects(:where).returns([Sequencescape::Api::V2::BarcodePrinter.new(
+      print_service: 'PMB', name: 'Test Printer', barcode_type: 'something'
+    )])
     mock_barcode_sheet = mock('printer')
     mock_barcode_sheet.expects(:print!).raises(Errno::ECONNREFUSED)
     BarcodeSheet.expects(:new).returns(mock_barcode_sheet)


### PR DESCRIPTION
Closes #562

#### Changes proposed in this pull request

- Updates barcode labels controller to use Sequencescape V2 API.

**Additional context**
Tested on UAT, printing okay 👌 
