### PR TITLE
Y25-482 - Print using v2 - 1

### DIFF
--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -6,13 +6,6 @@ namespace :config do
   task generate: :environment do
     api = Sequencescape::Api.new(Gatekeeper::Application.config.api_connection_options)
 
-    barcode_printer_uuid = lambda do |printers|
-      ->(printer_name) {
-        printers.detect { |prt| prt.name == printer_name }.try(:uuid) ||
-          raise("Printer #{printer_name}: not found!")
-      }
-    end.(api.barcode_printer.all)
-
     # Build the configuration file based on the server we are connected to.
     CONFIG = {}.tap do |configuration|
       configuration[:searches] = {}.tap do |searches|
@@ -25,8 +18,8 @@ namespace :config do
       configuration[:printers] = Hash.new { |h, i| h[i] = Array.new }.tap do |printers|
         approved_printers = Gatekeeper::Application.config.approved_printers
         puts 'Preparing printers ...'
-        selected = api.barcode_printer.all.select { |printer| printer.active && (approved_printers == :all || approved_printers.include?(printer.name)) }
-        selected.each { |printer| printers[printer.type.name] << { name: printer.name, uuid: printer.uuid } }
+        selected = Sequencescape::Api::V2::BarcodePrinter.all.select { |printer| printer.active && (approved_printers == :all || approved_printers.include?(printer.name)) }
+        selected.each { |printer| printers[printer.barcode_type] << { name: printer.name, uuid: printer.uuid } }
       end
 
       # Might want to switch this out for something more dynamic, but seeing as we'll almost certainly be working with a filtered set

--- a/test/models/barcode_sheet_test.rb
+++ b/test/models/barcode_sheet_test.rb
@@ -19,8 +19,9 @@ class BarcodeSheetTest < ActiveSupport::TestCase
 
   test '#initialise' do
     received_labels = [BarcodeSheet::Label.new(barcode: 'DN1S', prefix: 'DN', number: '1', lot: 'lot_number', template: 'tag_set')]
-    printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
-    printer.stubs(:print_service).returns('PMB')
+    printer = Sequencescape::Api::V2::BarcodePrinter.new(
+      print_service: 'PMB', name: @printer_name, barcode_type: '96 Well Plate'
+    )
 
     barcode_sheet = BarcodeSheet.new(printer, received_labels)
     assert_equal barcode_sheet.printer.name, @printer_name
@@ -44,9 +45,9 @@ class BarcodeSheetTest < ActiveSupport::TestCase
         barcode: 'DN1S'
       }]
 
-      printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
-
-      printer.stubs(:print_service).returns('PMB')
+      printer = Sequencescape::Api::V2::BarcodePrinter.new(
+        print_service: 'PMB', name: @printer_name, barcode_type: '96 Well Plate'
+      )
 
       PMB::TestSuiteStubs.get(@label_template_url) do |_env|
         [
@@ -74,9 +75,9 @@ class BarcodeSheetTest < ActiveSupport::TestCase
     Timecop.freeze(Date.parse('02-02-2019')) do
       received_labels = [BarcodeSheet::Label.new(barcode: 'DN1S', prefix: 'DN', number: '1', lot: 'lot_number', template: 'tag_set')]
 
-      printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
-
-      printer.stubs(:print_service).returns('SPrint')
+      printer = Sequencescape::Api::V2::BarcodePrinter.new(
+        print_service: 'SPrint', name: @printer_name, barcode_type: '96 Well Plate'
+      )
 
       response = mock('response')
       response.stubs(:code).returns('200')
@@ -91,9 +92,9 @@ class BarcodeSheetTest < ActiveSupport::TestCase
     Timecop.freeze(Date.parse('02-02-2019')) do
       received_labels = [BarcodeSheet::Label.new(barcode: 'DN1S', prefix: 'DN', number: '1', lot: 'lot_number', template: 'tag_set')]
 
-      printer = api.barcode_printer.find('baac0dea-0000-0000-0000-000000000000')
-
-      printer.stubs(:print_service).returns('SPrint')
+      printer = Sequencescape::Api::V2::BarcodePrinter.new(
+        print_service: 'SPrint', name: @printer_name, barcode_type: '96 Well Plate'
+      )
 
       response = mock('response')
       response.stubs(:code).returns('422')


### PR DESCRIPTION
Related to https://github.com/sanger/gatekeeper/issues/562

#### Changes proposed in this pull request

- Removes references to v1 barcode printer api in config rake

### Additional context

I managed to miss these references in https://github.com/sanger/gatekeeper/pull/639 so this PR cleans up the remaining ones.

Sequencescape support PR: https://github.com/sanger/sequencescape/pull/5505