### PR TITLE
Y26-035 - Add health endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'concurrent-ruby', '<= 1.3.4' # see https://github.com/rails/rails/issues/54
 gem 'csv'
 gem 'drb'
 gem 'exception_notification'
+gem 'faraday' # used for Sequencescape health check
 gem 'hashie'
 gem 'jquery-rails'
 gem 'json_api_client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,7 @@ DEPENDENCIES
   csv
   drb
   exception_notification
+  faraday
   hashie
   jquery-rails
   json_api_client

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,8 +1,29 @@
 # frozen_string_literal: true
 
 class HealthController < ActionController::Base # rubocop:disable Rails/ApplicationController
-  # Inherits from ActionController::Base to avoid any dependencies on Sequencescape
+  # Inherits from ActionController::Base to avoid implied dependencies on Sequencescape
+
+  # Health endpoint
+  #
+  # Check connection to Sequencescape by making a health request, returns 200 if successful, or 502/504 if not.
   def show
-    render plain: 'OK'
+    sequencescape_conn.get('/health')
+    render plain: 'OK', status: :ok
+  rescue Faraday::TimeoutError
+    render plain: 'Connection to Sequencescape timed out', status: :gateway_timeout
+  rescue Faraday::Error
+    render plain: 'Sequencescape is unavailable', status: :bad_gateway
+  end
+
+  def sequencescape_conn
+    @sequencescape_conn ||= Faraday.new(url: sequencescape_url) do |faraday|
+      faraday.response :raise_error # raise Faraday::Error on status code 4xx or 5xx
+    end
+  end
+
+  private
+
+  def sequencescape_url
+    Gatekeeper::Application.config.api_connection_options[:url]
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class HealthController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  # Inherits from ActionController::Base to avoid any dependencies on Sequencescape
+  def show
+    render plain: 'OK'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   root 'pages#index'
 
+  get 'health' => 'health#show', as: :health
+
   resources :lots, only: %i[create show new], constraints: { id: /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/ } do
     collection do
       get :search

--- a/test/controllers/health_controller_test.rb
+++ b/test/controllers/health_controller_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HealthControllerTest < ActionDispatch::IntegrationTest
+  test 'should get health' do
+    get health_url
+    assert_response :success
+    assert_equal 'OK', @response.body.strip
+  end
+end

--- a/test/controllers/health_controller_test.rb
+++ b/test/controllers/health_controller_test.rb
@@ -2,10 +2,43 @@
 
 require 'test_helper'
 
-class HealthControllerTest < ActionDispatch::IntegrationTest
-  test 'should get health' do
-    get health_url
+class HealthControllerTest < ActionController::TestCase
+  test 'returns OK when Sequencescape is available' do
+    test_conn = Faraday.new do |builder|
+      builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/health') { |_env| [200, {}, 'OK'] }
+      end
+    end
+    @controller.stubs(:sequencescape_conn).returns(test_conn)
+
+    get :show
     assert_response :success
-    assert_equal 'OK', @response.body.strip
+    assert_equal 'OK', @response.body
+  end
+
+  test 'returns Gateway Timeout when Sequencescape connection times out' do
+    test_conn = Faraday.new do |builder|
+      builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/health') { |_env| raise Faraday::TimeoutError }
+      end
+    end
+    @controller.stubs(:sequencescape_conn).returns(test_conn)
+
+    get :show
+    assert_response :gateway_timeout
+    assert_equal 'Connection to Sequencescape timed out', @response.body
+  end
+
+  test 'returns Bad Gateway when Sequencescape is unavailable' do
+    test_conn = Faraday.new do |builder|
+      builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/health') { |_env| raise Faraday::ServerError, 'Internal server error' }
+      end
+    end
+    @controller.stubs(:sequencescape_conn).returns(test_conn)
+
+    get :show
+    assert_response :bad_gateway
+    assert_equal 'Sequencescape is unavailable', @response.body
   end
 end


### PR DESCRIPTION
Adds a dedicated health endpoint as part of https://github.com/sanger/General-Backlog-Items/issues/700

#### Changes proposed in this pull request

- Add `HealthController` and `/health` endpoint

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
