### PR TITLE
[ux] Use .release-version file to populate version

### DIFF
--- a/lib/deployed_version.rb
+++ b/lib/deployed_version.rb
@@ -29,7 +29,7 @@ module Deployed
     end
 
     def label
-      tag.presence || branch
+      tag.presence || branch || read_file('.release-version').strip.presence
     end
 
     def major
@@ -49,7 +49,7 @@ module Deployed
     end
 
     def version_hash
-      @version_hash ||= /\Av(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<extra>\S*)/.match(label)
+      @version_hash ||= /\Av?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<extra>\S*)/.match(label)
     end
 
     def version_label


### PR DESCRIPTION
Shows the correct version on deployment instead of WIP

#### Changes proposed in this pull request

- Read the `.release-version` file to populate the version value

Before:
<img width="838" height="147" alt="Screenshot 2026-05-06 at 14 58 54" src="https://github.com/user-attachments/assets/828026d4-7be2-4686-a0ef-06e480cb38a4" />


After (with minor tweaking for local dev):
<img width="870" height="145" alt="Screenshot 2026-05-06 at 14 58 12" src="https://github.com/user-attachments/assets/d8190936-8cc4-4a91-9536-489489aa5a4a" />



#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
