### PR TITLE
Y25-607 - Restore barcode printer functionality

### DIFF
--- a/app/assets/javascripts/printers.js
+++ b/app/assets/javascripts/printers.js
@@ -1,0 +1,84 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.
+(function (window, $, undefined) {
+  var otherError;
+  // Basic Error Handling
+  otherError = function (response) {
+    var message, text;
+    message = $(".hidden .unknown-error").clone();
+    text =
+      (response.responseJSON || [])["error"] ||
+      message.children(".critical-error-message").text();
+    message.children(".critical-error-message").text(text);
+    $("#flash-holder").append(message);
+  };
+
+  /* Ideally this would go elsewhere, but then I'd either pollute the global namespace,
+     or need to add dependency management */
+  BarcodePrinter = function (form, type) {
+    this.form = $(form);
+    this.form.on("submit", this.formSubmit());
+    this.type = type || this.type;
+    this.form.find(this.remove()).hide();
+    this.form.find(this.show()).show();
+    this.form.find("select").val($(this.show()).val());
+  };
+  BarcodePrinter.prototype = {
+    formSubmit: function () {
+      var print = this;
+      return function (e) {
+        e.preventDefault();
+        print.form.find("button").attr("disabled", "disabled");
+        $.ajax({
+          type: "POST",
+          dataType: "json",
+          url: print.form[0].action,
+          data: print.form.serialize(),
+        }).then(print.pass(), print.fail());
+      };
+    },
+    fail: function () {
+      var print = this;
+      return function (response) {
+        console.log(response);
+        otherError();
+      };
+    },
+    pass: function () {
+      var print = this;
+      return function (response) {
+        print.form.find("button").attr("disabled", false);
+        print.form.find(".bc-feedback").append(print.message(response));
+      };
+    },
+    message: function (response) {
+      var guide, box;
+      guide = {
+        success: ["success", "glyphicon-ok"],
+        error: ["danger", "glyphicon-exclamation-sign"],
+      };
+      box = $(document.createElement("div"));
+      $.each(response, function (status, message) {
+        span = $(document.createElement("span")).addClass(
+          "glyphicon " + guide[status][1],
+        );
+        box
+          .addClass("alert alert-" + guide[status][0])
+          .append(span)
+          .append(" " + message);
+      });
+      return box;
+    },
+    remove: function () {
+      return this.type === "plate" ? ".tube-printer" : ".plate-printer";
+    },
+    show: function () {
+      return "." + this.type + "-printer";
+    },
+    type: "plate",
+  };
+
+  $(".barcode-printing-form").each(function () {
+    new BarcodePrinter(this);
+  });
+})(window, jQuery, undefined);

--- a/app/assets/javascripts/printers.js
+++ b/app/assets/javascripts/printers.js
@@ -21,7 +21,6 @@
     this.type = type || this.type;
     this.form.find(this.remove()).hide();
     this.form.find(this.show()).show();
-    this.form.find("select").val($(this.show()).val());
   };
   BarcodePrinter.prototype = {
     formSubmit: function () {

--- a/app/controllers/barcode_labels_controller.rb
+++ b/app/controllers/barcode_labels_controller.rb
@@ -27,12 +27,15 @@ class BarcodeLabelsController < ApplicationController
   private
 
   def generate_labels
-    permitted_params = params.permit(:study, barcodes: {})
     @labels = (permitted_params[:barcodes] || {}).to_h.map do |_, human_readable|
       BarcodeSheet::Label.new(
         human_readable:,
         study: permitted_params[:study]
       )
     end
+  end
+
+  def permitted_params
+    params.except(:authenticity_token).permit(:study, :barcode_printer, barcodes: {})
   end
 end

--- a/app/controllers/concerns/barcode_printing.rb
+++ b/app/controllers/concerns/barcode_printing.rb
@@ -4,6 +4,16 @@
 # Include to provide barcode printing functionality to a controller
 module BarcodePrinting
   def find_printer
-    @printer = Sequencescape::Api::V2::BarcodePrinter.where(uuid: params[:barcode_printer]).first
+    @printer = Sequencescape::Api::V2::BarcodePrinter.where(uuid: printer_uuid).first
+  end
+
+  private
+
+  def printer_uuid
+    permitted_params[:barcode_printer]
+  end
+
+  def permitted_params
+    params.require(:barcode_printer)
   end
 end

--- a/app/controllers/qcables_controller.rb
+++ b/app/controllers/qcables_controller.rb
@@ -22,10 +22,10 @@ class QcablesController < ApplicationController
       flash[:success] = "#{qcable_creator.qcables.count} #{qcable_name.pluralize} have been created." if qcable_creator
     end
 
-    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
+    redirect_to_lot
   rescue Net::ReadTimeout
     flash[:danger] = "Things are taking a bit longer than expected; your #{qcable_name.pluralize} are still being created in the background. Please check back later."
-    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
+    redirect_to_lot
   end
 
   # Create IDT tag plate hits here
@@ -35,10 +35,10 @@ class QcablesController < ApplicationController
 
     flash[:success] = "#{qc_creator.qcables.count} #{qcable_name.pluralize} have been created." if qc_creator
 
-    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
+    redirect_to_lot
   rescue Net::ReadTimeout
     flash[:danger] = "Things are taking a bit longer than expected; your #{qcable_name.pluralize} are still being created in the background. Please check back later."
-    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
+    redirect_to_lot
   end
 
   private
@@ -48,8 +48,16 @@ class QcablesController < ApplicationController
     (Settings.lot_types[@lot.lot_type_name] || @lot.lot_type).qcable_name
   end
 
+  def redirect_to_lot
+    redirect_to controller: :lots, action: :show, id: lot_uuid
+  end
+
   def find_lot
-    @lot = Sequencescape::Api::V2::Lot.where(uuid: permitted_params[:lot_id]).first
+    @lot = Sequencescape::Api::V2::Lot.where(uuid: lot_uuid).first
+  end
+
+  def lot_uuid
+    permitted_params[:lot_id]
   end
 
   def permitted_params

--- a/app/controllers/qcables_controller.rb
+++ b/app/controllers/qcables_controller.rb
@@ -15,30 +15,30 @@ class QcablesController < ApplicationController
   # pre stamped plates - _create_children
   def create
     # Make a qcable creator with the supplied count, under an existing lot, in SS.
-    qcable_creator = create_qcable_creator({ count: params[:plate_number].to_i })
+    qcable_creator = create_qcable_creator({ count: permitted_params[:plate_number].to_i })
 
     if qcable_creator
       print_labels(qcable_creator)
       flash[:success] = "#{qcable_creator.qcables.count} #{qcable_name.pluralize} have been created." if qcable_creator
     end
 
-    redirect_to controller: :lots, action: :show, id: params[:lot_id]
+    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
   rescue Net::ReadTimeout
     flash[:danger] = "Things are taking a bit longer than expected; your #{qcable_name.pluralize} are still being created in the background. Please check back later."
-    redirect_to controller: :lots, action: :show, id: params[:lot_id]
+    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
   end
 
   # Create IDT tag plate hits here
   def upload
     # Make a qcable creator with the supplied barcodes, under an existing lot, in SS.
-    qc_creator = create_qcable_creator({ barcodes: PlateUploader.new(params[:upload]).payload })
+    qc_creator = create_qcable_creator({ barcodes: PlateUploader.new(permitted_params[:upload]).payload })
 
     flash[:success] = "#{qc_creator.qcables.count} #{qcable_name.pluralize} have been created." if qc_creator
 
-    redirect_to controller: :lots, action: :show, id: params[:lot_id]
+    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
   rescue Net::ReadTimeout
     flash[:danger] = "Things are taking a bit longer than expected; your #{qcable_name.pluralize} are still being created in the background. Please check back later."
-    redirect_to controller: :lots, action: :show, id: params[:lot_id]
+    redirect_to controller: :lots, action: :show, id: permitted_params[:lot_id]
   end
 
   private
@@ -49,7 +49,11 @@ class QcablesController < ApplicationController
   end
 
   def find_lot
-    @lot = Sequencescape::Api::V2::Lot.where(uuid: params[:lot_id]).first
+    @lot = Sequencescape::Api::V2::Lot.where(uuid: permitted_params[:lot_id]).first
+  end
+
+  def permitted_params
+    params.except(:authenticity_token).permit(:user_swipecard, :lot_id, :plate_number, :upload, :barcode_printer)
   end
 
   def create_qcable_creator(attributes = {})

--- a/spec/features/lots_show_actions_spec.rb
+++ b/spec/features/lots_show_actions_spec.rb
@@ -123,12 +123,17 @@ RSpec.describe 'Lot show actions', type: :feature, js: true do
 
     visit lot_path(lot_uuid)
     within('.barcode-printing-form') do
+      #  Check that a default printer is selected
+      expect(page).to have_select('barcode_printer', selected: 'plate_example')
+
+      # Test printing
       find("input[name='barcodes[DN1]']").check
       select 'plate_example', from: 'barcode_printer'
       click_button 'Print'
     end
 
-    expect(page).to have_content('Your barcodes have been printed')
+    # Expect a feedback message in the Tag Plates card
+    expect(page).to have_css('.bc-feedback', text: 'Your barcodes have been printed')
   end
 
   it 'creates an IDT tag plate from upload when one does not exist' do


### PR DESCRIPTION
Closes feedback message not being correctly displayed on printing ([slack thread](https://psd-team.slack.com/archives/C095N1K4W80/p1784643466714279?thread_ts=1784563632.601909&cid=C095N1K4W80)).

#### Changes proposed in this pull request

- Add more test details to catch failing behaviour
- Restore deleted printer management JS (from previous [qc.js.erb](https://github.com/sanger/gatekeeper/blob/d4e441aab1ffe870084d72b91791e6b36fc6677c/app/assets/javascripts/qc.js.erb))
- Don't set a default printer on page load (ironically this makes the default printer visible)
- Refactor permitted parameters to remove warnings

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
